### PR TITLE
Move redirects into Next config object

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;
-module.exports = {
   async redirects() {
     return [];
   },
 };
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
- move the redirects handler into the exported Next.js config object
- drop the redundant CommonJS module.exports block and keep the default export only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97e94d0c8832bbf2241a715ede817